### PR TITLE
Delete old target figure before processing the actions.

### DIFF
--- a/src/imageprocessing/actions_list.py
+++ b/src/imageprocessing/actions_list.py
@@ -24,6 +24,10 @@ ACTION_CLASSES = []  # Is filled at the bottom of the module.
 class ActionList(composed_component.Builder):
     def __init__(self, parent: component.Composed):
         """ActionList constructor."""
+        if len(ACTION_CLASSES) == 0:
+            # Ensure all ImageAction subclasses are imported once.
+            ACTION_CLASSES.extend(ImageAction.get_subclasses())
+
         super().__init__()
 
         # Add components from JSON definition.
@@ -359,8 +363,3 @@ class Mirror(ImageAction):
         with Image.open(image_file) as im:
             new_image = ImageOps.mirror(im)
             new_image.save(target_file)
-
-
-if len(ACTION_CLASSES) == 0:
-    # Ensure all ImageAction subclasses are imported once.
-    ACTION_CLASSES.extend(ImageAction.get_subclasses())

--- a/src/imageprocessing/image_generator.py
+++ b/src/imageprocessing/image_generator.py
@@ -82,6 +82,7 @@ def process_files(meta_data: dict, payload: dict) -> dict:
 
     # Prepare output locations.
     target_fig = str(temp_target_folder / fig)
+    Path(target_fig).unlink(missing_ok=True)
     apply_action(payload, None, target_fig)
 
     # Put the created file in the ResultFile component for the user to download.

--- a/src/imageprocessing/image_processor.py
+++ b/src/imageprocessing/image_processor.py
@@ -81,6 +81,7 @@ def process_files(meta_data: dict, payload: dict) -> dict:
 
     # Prepare output locations.
     target_fig = str(temp_target_folder / fig)
+    Path(target_fig).unlink(missing_ok=True)
     apply_action(payload, full_fig, target_fig)
 
     # Put the created file in the ResultFile component for the user to download.


### PR DESCRIPTION
Defer ACTION_CLASSES filling to allow other modules to define ImageActions that are then automatically added to the list.

(inpainter uses the target figure to store the mask in)